### PR TITLE
feat: Implement per-level difficulty and power-up progression

### DIFF
--- a/alien_invasion/settings.py
+++ b/alien_invasion/settings.py
@@ -79,62 +79,140 @@ class Settings():
         self.menu_exit_button_text = "Выход"
 
         # Настройки бонусов
-        # Общий шанс появления любого бонуса (может быть уточнено позже при необходимости)
-        self.powerup_general_spawn_chance = 0.1 # Пример: 10% шанс появления бонуса
+        # self.powerup_general_spawn_chance = 0.1 # Removed: Now per-level
 
         # Бонус "Щит"
         self.shield_duration = 5000  # миллисекунды (5 секунд)
-        self.shield_spawn_chance = 0.1  # Конкретный шанс, если выбран из общего шанса появления, или независимый. Текущий план: независимый.
+        # self.shield_spawn_chance = 0.1 # Removed: Now per-level
         # Визуальные свойства бонуса "Щит"
         self.shield_powerup_color = (0, 0, 255)  # Синий
         self.shield_powerup_width = 15
         self.shield_powerup_height = 15
-        self.shield_powerup_speed = 1.0 # Скорость падения бонуса
+        self.shield_powerup_speed = 0.4 # Скорость падения бонуса
         # Визуальный эффект щита корабля
         self.ship_shield_outline_color = (0, 191, 255)  # Ярко-голубой (Deep sky blue)
 
         # Бонус "Двойной выстрел"
         self.double_fire_duration = 10000  # мс (10 секунд)
-        self.double_fire_spawn_chance = 0.05 # 5% шанс появления (теперь независимый и с кулдауном)
-        self.double_fire_min_cooldown = 15000 # Минимальный кулдаун в мс (15 секунд) для появления следующего бонуса "Двойной выстрел"
+        # self.double_fire_spawn_chance = 0.05 # Removed: Now per-level
+        # self.double_fire_min_cooldown = 15000 # Removed: Now per-level
         # Визуальные свойства бонуса "Двойной выстрел"
         self.double_fire_powerup_color = (255, 165, 0)  # Оранжевый
         self.double_fire_powerup_width = 15
         self.double_fire_powerup_height = 15
-        self.double_fire_powerup_speed = 1.0 # Скорость падения бонуса
+        self.double_fire_powerup_speed = 0.4 # Скорость падения бонуса
 
-        self.initialize_dynamic_settings()
+        # Level settings
+        self.level_settings = [
+            { # Level 1 Settings
+                'min_alien_speed': 0.3,
+                'alien_speed_increase_rate': 0.0,
+                'alien_speed_max_level': 0.3,
+                'fleet_drop_speed': 8,
+                'aliens_per_row_factor': 0.7,
+                'alien_rows_factor': 0.5,
+                'alien_points': 50,
+                'shield_spawn_chance': 0.0,
+                'double_fire_spawn_chance': 0.0,
+                'double_fire_min_cooldown': 999999, # Effectively infinite
+                'powerup_general_min_level_time': 999999, # Effectively infinite
+            },
+            { # Level 2 Settings
+                'min_alien_speed': 0.5,
+                'alien_speed_increase_rate': 0.00005,
+                'alien_speed_max_level': 0.7,
+                'fleet_drop_speed': 10,
+                'aliens_per_row_factor': 0.85,
+                'alien_rows_factor': 0.7,
+                'alien_points': 75,
+                'shield_spawn_chance': 0.1,
+                'double_fire_spawn_chance': 0.0,
+                'double_fire_min_cooldown': 999999, # Effectively infinite for DF
+                'powerup_general_min_level_time': 5000, # 5 seconds
+            },
+            { # Level 3 Settings
+                'min_alien_speed': 0.7,
+                'alien_speed_increase_rate': 0.0001,
+                'alien_speed_max_level': 1.2,
+                'fleet_drop_speed': 12,
+                'aliens_per_row_factor': 1.0,
+                'alien_rows_factor': 0.9,
+                'alien_points': 100,
+                'shield_spawn_chance': 0.07,
+                'double_fire_spawn_chance': 0.05,
+                'double_fire_min_cooldown': 15000, # 15 seconds
+                'powerup_general_min_level_time': 3000, # 3 seconds
+            }
+        ]
+        self.current_level_number = 1 # Default to level 1
 
-    def initialize_dynamic_settings(self):
-        """Инициализирует настройки, изменяющиеся в ходе игры"""
-        # Сброс настроек скорости к их начальным значениям
-        self.ship_speed = 1.5
-        self.bullet_speed = 1.5
-        # self.alien_speed = 1.0 # Удалено, теперь управляется alien_speed_current, который сбрасывается до min_alien_speed
-        self.alien_speed_current = self.min_alien_speed # Сброс текущей скорости до минимальной для новой игры/уровня
+        self.initialize_dynamic_settings(self.current_level_number)
+
+    def get_current_level_settings(self, level_number):
+        """Возвращает словарь настроек для указанного уровня."""
+        # Уровень нумеруется с 1, а список с 0
+        level_index = level_number - 1
+        if level_index < 0:
+            level_index = 0 # Безопасность, если вдруг передан некорректный уровень
+        if level_index >= len(self.level_settings):
+            # Если запрошенный уровень превышает количество определенных,
+            # используем настройки последнего определенного уровня (или можно ввести множители)
+            return self.level_settings[-1]
+        return self.level_settings[level_index]
+
+    def initialize_dynamic_settings(self, level_number):
+        """Инициализирует настройки, изменяющиеся в ходе игры, на основе текущего уровня."""
+        self.current_level_number = level_number
+        level_config = self.get_current_level_settings(level_number)
+
+        # Сброс общих настроек скорости корабля и снарядов (могут не зависеть от уровня)
+        self.ship_speed = 1.5 # Или можно сделать частью level_settings, если нужно
+        self.bullet_speed = 1.5 # Или можно сделать частью level_settings
+
+        # Настройки пришельцев из данных уровня
+        self.min_alien_speed = level_config.get('min_alien_speed', 0.5)
+        self.alien_speed_current = self.min_alien_speed # Начальная скорость пришельцев для уровня
+        # Ensure alien_speed_increase_rate and alien_speed_max_level are loaded
+        self.alien_speed_increase_rate = level_config.get('alien_speed_increase_rate', 0.0)
+        self.alien_speed_max_level = level_config.get('alien_speed_max_level', self.alien_speed_current)
+
+        self.fleet_drop_speed = level_config.get('fleet_drop_speed', 10)
+        self.alien_points = level_config.get('alien_points', 50)
+
+        # Факторы для расчета количества пришельцев, делаем их доступными как атрибуты
+        self.current_aliens_per_row_factor = level_config.get('aliens_per_row_factor', 1.0)
+        self.current_alien_rows_factor = level_config.get('alien_rows_factor', 1.0)
+
+        # Power-up settings from level_config
+        self.current_shield_spawn_chance = level_config.get('shield_spawn_chance', 0.0)
+        self.current_double_fire_spawn_chance = level_config.get('double_fire_spawn_chance', 0.0)
+        self.current_double_fire_min_cooldown = level_config.get('double_fire_min_cooldown', 999999)
+        self.current_powerup_general_min_level_time = level_config.get('powerup_general_min_level_time', 999999)
+
 
         # fleet_direction = 1 обозначает движение вправо, а -1 влево
         self.fleet_direction = 1
 
-        # Подсчет очков
-        self.alien_points = 50
+        # Глобальный alien_speed_max все еще может быть полезен для DDA, если DDA выходит за рамки одного уровня
+        # self.alien_speed_max = 3.0 # Этот атрибут теперь менее важен, т.к. есть alien_speed_max_level
+
+    def load_level_settings(self, new_level_number):
+        """Загружает настройки для нового уровня."""
+        print(f"Loading settings for level {new_level_number}")
+        self.initialize_dynamic_settings(new_level_number)
 
     def increase_speed(self):
-        """Увеличивает настройки скорости и стоимость пришельцев"""
+        """Увеличивает настройки скорости корабля и снарядов.
+           Скорость пришельцев и очки теперь управляются через load_level_settings."""
         self.ship_speed *= self.speedup_scale
         self.bullet_speed *= self.speedup_scale
-        # self.alien_speed *= self.speedup_scale # Теперь увеличивает min_alien_speed для следующего уровня
-        self.min_alien_speed *= self.speedup_scale # Увеличить базовую (минимальную) скорость для следующего уровня
-        # Убедиться, что min_alien_speed не превышает alien_speed_max после увеличения.
-        # Текущая логика DDA будет использовать alien_speed_current, который ограничивается alien_speed_max.
-        # Это изменение влияет на базовую скорость для начала следующего уровня или после сброса.
-
-        self.alien_points = int(self.alien_points * self.score_scale)
+        # self.min_alien_speed *= self.speedup_scale # Удалено, управляется настройками уровня
+        # self.alien_points = int(self.alien_points * self.score_scale) # Удалено, управляется настройками уровня
 
         # Логирование изменения скорости
-        print(f"--- Speed Increased ---")
+        print(f"--- Ship/Bullet Speed Increased (Global Scale) ---")
         print(f"New ship speed: {self.ship_speed:.2f}")
         print(f"New bullet speed: {self.bullet_speed:.2f}")
-        print(f"New min alien speed for next level: {self.min_alien_speed:.2f}") # Обновленное сообщение в логе
-        print(f"New alien points: {self.alien_points}")
+        # print(f"New min alien speed for next level: {self.min_alien_speed:.2f}") # Это больше не актуально здесь
+        # print(f"New alien points: {self.alien_points}") # Это также не актуально здесь
         print(f"-----------------------")


### PR DESCRIPTION
This commit introduces a more granular control over game difficulty and power-up spawning across different levels, based on issue feedback.

Key changes:

1.  **Level-Specific Settings:**
    - Modified `settings.py` to store core difficulty parameters (alien speed, fleet density, points) and power-up rules (spawn chances, cooldowns, minimum level time) in a per-level structure.
    - `alien_invasion.py` now loads and applies these settings dynamically as you progress through levels.

2.  **Difficulty Curve Implementation:**
    - Defined distinct characteristics for Level 1 (easy), Level 2 (medium), and Level 3 (hard).
    - Level 1: Reduced alien speed and fleet size, no intra-level speed increase.
    - Level 2: Moderate alien speed with a slight intra-level increase, increased fleet density compared to Level 1.
    - Level 3: Higher starting alien speed with a more noticeable intra-level increase, and near-full fleet density.
    - Alien speed progression within a level is now controlled by a per-level increase rate and maximum speed cap, replacing the previous global score-based DDA for alien speed.

3.  **Power-Up Spawn Logic per Level:**
    - Level 1: No power-ups.
    - Level 2: Only Shield power-ups can spawn, after a minimum time has passed in the level.
    - Level 3: Both Shield and Double Laser power-ups can spawn, each with configurable chances and cooldowns (for Double Laser), after a minimum time has passed in the level.

4.  **Adjusted Power-up Falling Speed:**
    - Reduced the falling speed for all power-ups to make them easier for you to collect.

These changes aim to create a smoother difficulty ramp and more engaging power-up mechanics, providing a better player experience. Further numerical balancing may be required based on extensive playtesting.